### PR TITLE
Add searching for popular films by genre & year

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -85,7 +85,7 @@ public class FilmController {
     }
 
     @GetMapping("/popular")
-    public Collection<Film> getPopular(@RequestParam(defaultValue = "10", required = false) Long count,
+    public Collection<Film> getPopular(@RequestParam(defaultValue = "10") Long count,
                                        @RequestParam(required = false) Integer genreId,
                                        @RequestParam(required = false) Integer year) {
         log.info("Пришел GET запрос /popular?count={}&genreId={}&year={}", count, genreId, year);

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -85,10 +85,12 @@ public class FilmController {
     }
 
     @GetMapping("/popular")
-    public Collection<Film> getPopular(@RequestParam(required = false) Long count) {
-        log.info("Пришел GET запрос /popular/count={}", count);
-        Collection<Film> topFilms = filmService.getTopFilmsByLike(count);
-        log.info("Отправлен ответ GET /popular/count={} с телом: {}", count, topFilms);
+    public Collection<Film> getPopular(@RequestParam(defaultValue = "10", required = false) Long count,
+                                       @RequestParam(required = false) Integer genreId,
+                                       @RequestParam(required = false) Integer year) {
+        log.info("Пришел GET запрос /popular?count={}&genreId={}&year={}", count, genreId, year);
+        Collection<Film> topFilms = filmService.getTopFilmsByLike(count, genreId, year);
+        log.info("Отправлен ответ GET /popular?count={}&genreId={}&year={} с телом: {}", count, genreId, year, topFilms);
         return topFilms;
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 @Service
 public class FilmService {
-    private static final long TOP_LIMIT_N = 10;
-
     private final FilmStorage filmStorage;
     private final UserService userService;
     private final GenreService genreService;

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -109,11 +109,8 @@ public class FilmService {
         return film;
     }
 
-    public List<Film> getTopFilmsByLike(Long count) {
-        if (count == null) {
-            count = TOP_LIMIT_N;
-        }
-        List<Film> films = filmStorage.getTopFilmsByLike(count);
+    public List<Film> getTopFilmsByLike(Long count, Integer genreId, Integer year) {
+        List<Film> films = filmStorage.getTopFilmsByLike(count, genreId, year);
         genreService.loadGenres(films);
         return films;
     }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -34,6 +34,28 @@ public class FilmDbStorage implements FilmStorage {
     private static final String DELETE_LIKE_QUERY = "DELETE FROM film_like WHERE film_id = ? AND user_id = ?";
     private static final String TOP_LIST_QUERY = "SELECT f.film_id, f.name, f.description, f.release_date, f.duration, f.rating_id, r.name as rating_name, l.likes FROM film AS f LEFT JOIN rating AS r ON f.rating_id = r.rating_id INNER JOIN (SELECT film_id, COUNT(DISTINCT user_id) AS likes FROM film_like GROUP BY film_id) AS l ON f.film_id = l.film_id ORDER BY likes DESC LIMIT ?";
 
+    private static final String FIND_POPULAR_QUERY =
+            """
+            SELECT f.film_id, f.name, f.description, f.release_date, f.duration, f.rating_id,
+                   r.name AS rating_name, fl.likes
+            FROM film AS f
+            LEFT JOIN rating AS r ON f.rating_id = r.rating_id
+            INNER JOIN
+              (SELECT film_id,
+                      COUNT(DISTINCT user_id) AS likes
+               FROM film_like
+               GROUP BY film_id) AS fl ON f.film_id = fl.film_id
+            WHERE (? IS NULL
+                   OR EXTRACT(YEAR
+                              FROM f.release_date) = ?)
+              AND (? IS NULL
+                   OR ? IN
+                     (SELECT genre_id
+                      FROM film_genre
+                      WHERE film_id = f.film_id))
+            ORDER BY fl.likes DESC
+            LIMIT ?""";
+
     @Override
     public Film create(Film film) {
         GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
@@ -117,5 +139,10 @@ public class FilmDbStorage implements FilmStorage {
     @Override
     public List<Film> getTopFilmsByLike(Long count) {
         return jdbc.query(TOP_LIST_QUERY, mapper, count);
+    }
+
+    @Override
+    public List<Film> getTopFilmsByLike(Long count, Integer genreId, Integer year) {
+        return jdbc.query(FIND_POPULAR_QUERY, mapper, year, year, genreId, genreId, count);
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -23,4 +23,8 @@ public interface FilmStorage {
     public void deleteLike(Film film, User user);
 
     public List<Film> getTopFilmsByLike(Long count);
+
+    default List<Film> getTopFilmsByLike(Long count, Integer genreId, Integer year) {
+        return getTopFilmsByLike(count);   // ignore genreId & year for in-memory storage
+    }
 }


### PR DESCRIPTION
Добавил поиск топ-N фильмов по количеству лайков.

В фильтрации участвуют опциональные параметры - ид. жанра и год выпуска фильма

API
GET /films/popular?count={limit}&genreId={genreId}&year={year}

Возвращает список N (по умолчанию 10) самых популярных фильмов указанного жанра за нужный год.